### PR TITLE
add basic service (api) scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Environment configuration for Cijene API service
+
+# Application version
+VERSION=0.1.0
+
+# Directory containing archive files
+ARCHIVE_DIR=data
+
+# Base URL for the API (used in archive URLs)
+BASE_URL=https://api.cijene.dev
+
+# Server host and port
+HOST=0.0.0.0
+PORT=8000
+
+# Debug mode (enables auto-reload and debug features)
+DEBUG=false
+
+# Timezone for file timestamps
+TIMEZONE=Europe/Zagreb
+
+# URL to redirect to from root endpoint
+REDIRECT_URL=https://cijene.dev

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ wheels/
 
 # Data
 data/
+
+# Configuration
+.env

--- a/README.md
+++ b/README.md
@@ -63,7 +63,17 @@ odabir datuma (default: trenutni dan), `-c` za odabir lanaca (default: svi) te
 
 ### Web servis
 
-Web servis je u izradi. Trenutno nije dostupan.
+Prije pokretanja servisa, kreirajte datoteku `.env` sa konfiguracijskim varijablama.
+Primjer datoteke sa zadanim (default) vrijednostima može se naći u `.env.example`.
+
+Nakon što ste kreirali `.env` datoteku, pokrenite servis koristeći:
+
+```bash
+uv run -m service.main
+```
+
+Servis će biti dostupan na `http://localhost:8000` (ako niste mijenjali port), a na
+`http://localhost:8000/docs` je dostupna Swagger dokumentacija API-ja.
 
 ## Licenca
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "lxml>=5.4.0",
     "openpyxl>=3.1.5",
     "pydantic>=2.11.4",
+    "python-dotenv>=1.1.0",
+    "uvicorn>=0.34.2",
 ]
 
 [tool.uv]

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI service for Cijene product pricing data."""

--- a/service/config.py
+++ b/service/config.py
@@ -1,0 +1,21 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Settings:
+    """Application settings loaded from environment variables."""
+
+    def __init__(self):
+        self.version: str = os.getenv("VERSION", "0.1.0")
+        self.archive_dir: str = os.getenv("ARCHIVE_DIR", "data")
+        self.base_url: str = os.getenv("BASE_URL", "https://api.cijene.dev")
+        self.host: str = os.getenv("HOST", "0.0.0.0")
+        self.port: int = int(os.getenv("PORT", "8000"))
+        self.debug: bool = os.getenv("DEBUG", "false").lower() == "true"
+        self.timezone: str = os.getenv("TIMEZONE", "Europe/Zagreb")
+        self.redirect_url: str = os.getenv("REDIRECT_URL", "https://cijene.dev")
+
+
+settings = Settings()

--- a/service/main.py
+++ b/service/main.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse, JSONResponse
+from fastapi.exceptions import HTTPException
+import uvicorn
+
+from service.routers import v0
+from service.config import settings
+
+app = FastAPI(
+    title="Cijene API",
+    description="Service for product pricing data by Croatian grocery chains",
+    version=settings.version,
+    debug=settings.debug,
+)
+
+# Include versioned routers
+app.include_router(v0.router, prefix="/v0")
+
+
+@app.exception_handler(404)
+async def custom_404_handler(request: Request, exc: HTTPException):
+    """Custom 404 handler with helpful message directing to API docs."""
+    return JSONResponse(
+        status_code=404,
+        content={"detail": "Resource not found. Check documentation at /docs"},
+    )
+
+
+@app.get("/")
+async def root():
+    """Root endpoint redirects to main website."""
+    return RedirectResponse(url=settings.redirect_url, status_code=302)
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "healthy"}
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "service.main:app",
+        host=settings.host,
+        port=settings.port,
+        reload=settings.debug,
+    )

--- a/service/routers/__init__.py
+++ b/service/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Routers package for versioned API endpoints."""

--- a/service/routers/v0.py
+++ b/service/routers/v0.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Any
+from zoneinfo import ZoneInfo
+from fastapi import APIRouter
+
+from service.config import settings
+
+router = APIRouter()
+
+
+def format_datetime_with_timezone(dt: datetime) -> str:
+    """
+    Format a datetime object with proper timezone information.
+
+    Args:
+        dt: A naive datetime object (assumed to be in the configured timezone)
+
+    Returns:
+        ISO 8601 formatted datetime string with timezone offset
+    """
+    # Assume the naive datetime is in the configured timezone
+    timezone = ZoneInfo(settings.timezone)
+    dt_with_tz = dt.replace(tzinfo=timezone)
+
+    # Remove microseconds and format as ISO string
+    return dt_with_tz.replace(microsecond=0).isoformat()
+
+
+def find_archives() -> list[tuple[str, int, datetime]]:
+    """
+    Find all ZIP archive files in the archive directory and return their metadata.
+
+    Assumes the filename pattern is `YYYY-MM-DD.zip`.
+
+    Returns:
+        List of tuples containing the date (filename without extension),
+        size, and modification time of each archive.
+    """
+
+    archive_path = Path(settings.archive_dir)
+    if not archive_path.is_dir():
+        return []
+
+    archives = []
+    for file_path in archive_path.iterdir():
+        if file_path.is_file() and file_path.suffix == ".zip":
+            date = file_path.stem
+            size = file_path.stat().st_size
+            mtime = datetime.fromtimestamp(file_path.stat().st_mtime)
+            archives.append((date, size, mtime))
+
+    # Sort by date in reverse chronological order (newest first)
+    archives.sort(key=lambda x: x[0], reverse=True)
+    return archives
+
+
+@router.get("/list")
+async def list_archives() -> Dict[str, List[Dict[str, Any]]]:
+    """List all available archive files with their metadata."""
+
+    archives = []
+    for date, size, mtime in find_archives():
+        url = f"{settings.base_url}/v0/archive/{date}.zip"
+        updated = format_datetime_with_timezone(mtime)
+        archives.append({"date": date, "url": url, "size": size, "updated": updated})
+
+    return {"archives": archives}

--- a/uv.lock
+++ b/uv.lock
@@ -65,6 +65,8 @@ dependencies = [
     { name = "lxml" },
     { name = "openpyxl" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -83,6 +85,8 @@ requires-dist = [
     { name = "lxml", specifier = ">=5.4.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pydantic", specifier = ">=2.11.4" },
+    { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "uvicorn", specifier = ">=0.34.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Sets up basic scaffolding for a FastAPI service with path-based namespacing, configuration via environment variables, Swagger UI docs, health checks and a simple endpoint to list available ZIP archives.