### PR TITLE
Add Docker support for crawler and service with cron job setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ wheels/
 
 # Data
 data/
+tmp/
+docker_data/
 
 # Configuration
 .env

--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -1,0 +1,33 @@
+FROM python:3.13-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Europe/Zagreb
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unzip cron tzdata gcc libxml2-dev libxslt-dev python3-dev build-essential && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+    beautifulsoup4>=4.13.4 \
+    httpx>=0.28.1 \
+    lxml>=5.4.0 \
+    openpyxl>=3.1.5 \
+    pydantic>=2.11.4 \
+    psycopg2-binary>=2.9.9 \
+    python-dotenv>=1.1.0 \
+    SQLAlchemy==2.0.41 \
+    dotenv>=0.9.9
+
+COPY crawler /app/crawler
+
+COPY docker/crawlercron /etc/cron.d/crawlercron
+RUN chown root:root /etc/cron.d/crawlercron
+RUN chmod 0644 /etc/cron.d/crawlercron && \
+    touch /var/log/cron.log
+
+VOLUME ["/data"]
+
+CMD ["cron", "-f"]

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Europe/Zagreb
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+    fastapi[standard]>=0.115.12 \
+    python-dotenv>=1.1.0 \
+    uvicorn>=0.34.2
+
+COPY service /app/service
+
+EXPOSE 8000
+
+CMD ["python", "-m", "service.main"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ uv run -m service.main
 Servis će biti dostupan na `http://localhost:8000` (ako niste mijenjali port), a na
 `http://localhost:8000/docs` je dostupna Swagger dokumentacija API-ja.
 
+## Docker
+
+Docker container crawler ima cronjob za pokretanje u 09h i 21h, definiran u `docker/crawlercron`
+
+Za pokretanje crawlera u Dockeru, potrebno je imati instaliran Docker i Docker Compose.
+Zatim, u root direktoriju projekta, pokrenite sljedeće komande:
+
+```bash
+docker compose up --build
+```
+
+Help:
+
+```bash
+docker compose exec -it crawler python -m crawler.cli.crawl -h
+```
+
+Primjer za pokretanje crawlera za KTC:
+
+```bash
+docker compose exec -it crawler python -m crawler.cli.crawl -c ktc /data
+```
+
 ## Licenca
 
 Ovaj projekt je licenciran pod [AGPL-3 licencom](LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  crawler:
+    build:
+      context: .
+      dockerfile: Dockerfile.crawler
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./docker_data/crawler:/data
+      - ./.env:/app/.env
+
+  service:
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./docker_data:/app/data
+    ports:
+      - "8000:8000"
+
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./docker_data/postgres:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"

--- a/docker/crawlercron
+++ b/docker/crawlercron
@@ -1,0 +1,6 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Cron job for crawler: run at 09:00 and 21:00 daily
+0 9,23 * * * root cd /app && set -a && source /app/.env && set +a && python -m crawler.cli.crawl /data >> /var/log/cron.log 2>&1
+


### PR DESCRIPTION
Dockerfile za crawler i service.

- cronjob 09h i 21h
- README.md sa par primjera