### PR TITLE
Add chain summaries

### DIFF
--- a/service/db/base.py
+++ b/service/db/base.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from .models import (
     Chain,
+    ChainSummary,
     ChainWithId,
     Product,
     ProductWithId,
@@ -54,6 +55,16 @@ class Database(ABC):
 
         Returns:
             A list of Chain objects representing all chains.
+        """
+        pass
+
+    @abstractmethod
+    async def list_latest_chain_summaries(self) -> list[ChainSummary]:
+        """
+        Returns the latest available chain summaries for each chain.
+
+        Returns:
+            A list of ChainSummary objects.
         """
         pass
 

--- a/service/db/base.py
+++ b/service/db/base.py
@@ -226,6 +226,19 @@ class Database(ABC):
         pass
 
     @abstractmethod
+    async def compute_chain_summaries(self, date: date) -> None:
+        """
+        Compute chain summaries for a specific date.
+
+        This method populates the store data summary for each chain on the given
+        date.
+
+        Args:
+            date: The date for which to compute summaries.
+        """
+        pass
+
+    @abstractmethod
     async def get_product_prices(
         self,
         product_ids: list[int],

--- a/service/db/import.py
+++ b/service/db/import.py
@@ -330,6 +330,9 @@ async def import_directory(path: Path) -> None:
 
         logger.debug(f"Computing average chain prices for {price_date:%Y-%m-%d}")
         await db.compute_chain_prices(price_date)
+
+        logger.debug(f"Computing chain summaries for {price_date:%Y-%m-%d}")
+        await db.compute_chain_summaries(price_date)
     finally:
         await db.close()
 

--- a/service/db/models.py
+++ b/service/db/models.py
@@ -25,6 +25,15 @@ class ChainWithId(Chain):
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class ChainSummary:
+    chain_code: str
+    price_date: date
+    price_count: int
+    store_count: int
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class Store:
     chain_id: int
     code: str

--- a/service/db/psql.sql
+++ b/service/db/psql.sql
@@ -16,6 +16,17 @@ CREATE TABLE IF NOT EXISTS chains (
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Chain summaries table to store the summary of loaded data per chain
+CREATE TABLE IF NOT EXISTS chain_summaries(
+    id SERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL REFERENCES chains (id),
+    price_date DATE NOT NULL,
+    price_count INTEGER NOT NULL,
+    store_count INTEGER NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (chain_id, price_date)
+);
+
 -- Stores table to store retailer locations
 CREATE TABLE IF NOT EXISTS stores (
     id SERIAL PRIMARY KEY,

--- a/service/routers/v1.py
+++ b/service/routers/v1.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 import datetime
 
 from service.config import settings
-from service.db.models import ProductWithId
+from service.db.models import ChainSummary, ProductWithId
 from service.routers.auth import RequireAuth
 
 router = APIRouter(tags=["Products, Chains and Stores"], dependencies=[RequireAuth])
@@ -259,3 +259,20 @@ async def search_products(
     )
 
     return ProductSearchResponse(products=product_responses)
+
+
+class ChainSummariesResponse(BaseModel):
+    chain_summaries: list[ChainSummary] = Field(
+        ..., description="List chain summaries."
+    )
+
+
+@router.get(
+    "/chain-summaries/",
+    summary="Return summaries of currently loaded data per chain."
+)
+async def chain_summaries() -> ChainSummariesResponse:
+    """Return summaries of currently loaded data per chain."""
+
+    chain_summaries = await db.list_latest_chain_summaries()
+    return ChainSummariesResponse(chain_summaries=chain_summaries)


### PR DESCRIPTION
The idea here is to get a feeling for the data that's currently served by the API. 

To accomplish this I added a database table and endpoint which will for every chain return a summary of the last loaded prices:

`GET /v1/chain-summaries/`

```json
{
  "chain_summaries": [
    {
      "chain_code": "kaufland",
      "price_date": "2025-06-06",
      "price_count": 680236,
      "store_count": 50,
      "created_at": "2025-06-06T16:35:41.937728Z"
    },
    ...
```

Where `price_date` is the last date for which the data is loaded and corresponding counts for that day.

To initially back-load summaries for past dates you can run this query:

```sql
INSERT INTO chain_summaries(
    chain_id,
    price_date,
    price_count,
    store_count,
    created_at
)
SELECT
    cp.chain_id,
    p.price_date,
    COUNT(*) AS price_count,
    COUNT(DISTINCT p.store_id) AS store_count,
    NOW() AS created_at
FROM prices p
JOIN chain_products cp ON cp.id = p.chain_product_id
GROUP BY 1, 2
ON CONFLICT (chain_id, price_date)
DO UPDATE SET
    price_count = EXCLUDED.price_count,
    store_count = EXCLUDED.store_count;
```
