### PR TITLE
Store prices endpoint

### DIFF
--- a/service/db/base.py
+++ b/service/db/base.py
@@ -11,6 +11,7 @@ from .models import (
     Store,
     ChainProduct,
     Price,
+    StorePrice,
     StoreWithId,
     ChainProductWithId,
     User,
@@ -272,6 +273,24 @@ class Database(ABC):
 
         Returns:
             Information for the specified products and date.
+        """
+        pass
+
+    @abstractmethod
+    async def get_product_store_prices(
+        self,
+        product_id: int,
+        chain_ids: list[int] | None,
+    ) -> list[StorePrice]:
+        """
+        For a given product return latest available prices per store.
+
+        Args:
+            product_id: The ID of the product to fetch
+            chain_ids: Optional list of chain IDs to filter by.
+
+        Returns:
+            A list of StorePrice objects
         """
         pass
 

--- a/service/db/models.py
+++ b/service/db/models.py
@@ -95,3 +95,16 @@ class Price:
     unit_price: Optional[Decimal] = None
     best_price_30: Optional[Decimal] = None
     anchor_price: Optional[Decimal] = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorePrice:
+    chain: str
+    ean: str
+    price_date: date
+    regular_price: Optional[Decimal]
+    special_price: Optional[Decimal]
+    unit_price: Optional[Decimal]
+    best_price_30: Optional[Decimal]
+    anchor_price: Optional[Decimal]
+    store: Store


### PR DESCRIPTION
This is an endpoint I'm currently missing - it returns the latest prices per store for a given product.

I did some testing and it runs pretty quickly without any additional indexes, on my machine ~14ms as measured by `time curl ...` for a worst-case scenario (fetching a popular product + no filtering by chain).