### PR TITLE
Refactor store prices endpoint to enable store filtering

### DIFF
--- a/service/db/base.py
+++ b/service/db/base.py
@@ -339,15 +339,15 @@ class Database(ABC):
     @abstractmethod
     async def get_product_store_prices(
         self,
-        product_id: int,
-        chain_ids: list[int] | None,
+        product_ids: list[int],
+        store_ids: list[int] | None = None,
     ) -> list[StorePrice]:
         """
-        For a given product return latest available prices per store.
+        For given products return latest available prices per store.
 
         Args:
-            product_id: The ID of the product to fetch
-            chain_ids: Optional list of chain IDs to filter by.
+            product_ids: The IDs of the products to fetch
+            store_ids: Optional list of store IDs to filter by.
 
         Returns:
             A list of StorePrice objects

--- a/service/db/psql.py
+++ b/service/db/psql.py
@@ -314,7 +314,9 @@ class PostgresDatabase(Database):
             return [ProductWithId(**row) for row in rows]  # type: ignore
 
     async def get_product_store_prices(
-        self, product_id: int, chain_ids: list[int] | None
+        self,
+        product_ids: list[int],
+        store_ids: list[int] | None = None,
     ) -> list[StorePrice]:
         async with self._get_conn() as conn:
             query = """
@@ -338,7 +340,10 @@ class PostgresDatabase(Database):
                     stores.type,
                     stores.address,
                     stores.city,
-                    stores.zipcode
+                    stores.zipcode,
+                    stores.lat,
+                    stores.lon,
+                    stores.phone
                 FROM chains_dates
                 JOIN chains ON chains.id = chains_dates.chain_id
                 JOIN chain_products ON chain_products.chain_id = chains.id
@@ -346,14 +351,18 @@ class PostgresDatabase(Database):
                 JOIN prices ON prices.chain_product_id = chain_products.id
                            AND prices.price_date = chains_dates.last_price_date
                 JOIN stores ON stores.id = prices.store_id
-                WHERE products.id = $1
+                WHERE products.id = ANY($1)
             """
 
-            if chain_ids:
-                query += "AND chains.id = ANY($2)"
-                rows = await conn.fetch(query, product_id, chain_ids)
-            else:
-                rows = await conn.fetch(query, product_id)
+            params = [product_ids]
+            param_idx = 2
+
+            if store_ids is not None:
+                query += f" AND stores.id = ANY(${param_idx})"
+                params.append(store_ids)
+                param_idx += 1
+
+            rows = await conn.fetch(query, *params)
 
             return [
                 StorePrice(
@@ -372,6 +381,9 @@ class PostgresDatabase(Database):
                         address=row["address"],
                         city=row["city"],
                         zipcode=row["zipcode"],
+                        lat=row["lat"],
+                        lon=row["lon"],
+                        phone=row["phone"],
                     ),
                 )
                 for row in rows

--- a/service/db/psql.sql
+++ b/service/db/psql.sql
@@ -50,9 +50,10 @@ ADD COLUMN IF NOT EXISTS lon DOUBLE PRECISION,
 ADD COLUMN IF NOT EXISTS phone VARCHAR(50);
 
 -- Requires "cube" and "earthdistance" extensions for geospatial queries
+CREATE EXTENSION IF NOT EXISTS cube;
+CREATE EXTENSION IF NOT EXISTS earthdistance;
 ALTER TABLE stores
 ADD COLUMN IF NOT EXISTS earth_point earth GENERATED ALWAYS AS (ll_to_earth (lat, lon)) STORED;
-
 CREATE INDEX IF NOT EXISTS idx_stores_earth_point ON stores USING GIST (earth_point);
 
 -- Products table to store global product information


### PR DESCRIPTION
Ovaj PR nadovezuje se na #24 i #26 , tako da dodaje mogućnost filtriranja po poslovnicama (po ulici, gradu ili geolokaciji) prilikom pretraživanja proizvoda. Također omogućuje pretraživanje više proizvoda odjednom (korisno za implementaciju košarice).

Zbog dodavanja podrške za više proizvoda, `/v1/products/{ean}/...` više ne funkcionira pa sam to proglasio novim endpointom `/v1/prices/`. Updateani endpoint podržava pretragu po barkodovima (bar jedan je potreban), lancima, adresom, gradom ili geolokacijom poslovnice.

@ihabunek pošto ovo dosta mijenja tvoj PR, svi komentari i kritike su dobrodošli.