### PR TITLE
Extract Statistics Service and Add Performance Options to Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,42 @@ predstavlja datum za koji se podaci uvoze, i sadržavati CSV datoteke u
 istom formatu kakve generira crawler (*ne* CSV datoteke skinute sa stranica
 nekog trgovačkog lanca!).
 
+##### Opcije za uvoz
+
+Moguće je preskočiti računanje statistika tijekom uvoza (što može značajno ubrzati proces):
+
+```bash
+uv run -m service.db.import -s /path/to/csv-folder/
+# ili
+uv run -m service.db.import --skip-stats /path/to/csv-folder/
+```
+
+Za debug informacije koristite `-d` opciju:
+
+```bash
+uv run -m service.db.import -d /path/to/csv-folder/
+```
+
+#### Računanje statistika
+
+Za računanje statistika bez uvoza podataka (korisno za već uvezene podatke), koristite dedicirani stats servis:
+
+```bash
+# Računanje statistika za jedan datum
+uv run -m service.db.stats 2024-01-15
+
+# Više datuma odjednom
+uv run -m service.db.stats 2024-01-15 2024-01-16 2024-01-17
+
+# S debug informacijama
+uv run -m service.db.stats -d 2024-01-15
+```
+
+Stats servis može se koristiti za:
+- **Ponovno računanje statistika** nakon promjena u bazi podataka
+- **Batch procesiranje** statistika za više datuma
+- **Nezavisan rad** od import procesa za bolje performanse
+
 ## Dodatni podaci o proizvodima
 
 Dodatni pročišćeni podaci o proizvodima (naziv, marka, količina, jedinica mjere)

--- a/service/db/import.py
+++ b/service/db/import.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 
 from service.config import settings
 from service.db.models import Chain, ChainProduct, Price, Store
+from service.db.stats import compute_stats
 
 logger = logging.getLogger("importer")
 
@@ -298,7 +299,7 @@ async def process_chain(
     logger.info(f"Imported {n_new_prices} new prices for {code}")
 
 
-async def import_archive(path: Path):
+async def import_archive(path: Path, compute_stats_flag: bool = True):
     """Import data from all chain directories in the given zip archive."""
     try:
         price_date = datetime.strptime(path.stem, "%Y-%m-%d")
@@ -310,10 +311,10 @@ async def import_archive(path: Path):
         logger.debug(f"Extracting archive {path} to {temp_dir}")
         with zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(temp_dir)
-        await _import(Path(temp_dir), price_date)
+        await _import(Path(temp_dir), price_date, compute_stats_flag)
 
 
-async def import_directory(path: Path) -> None:
+async def import_directory(path: Path, compute_stats_flag: bool = True) -> None:
     """Import data from all chain directories in the given directory."""
     if not path.is_dir():
         logger.error(f"`{path}` does not exist or is not a directory")
@@ -327,10 +328,10 @@ async def import_directory(path: Path) -> None:
         )
         return
 
-    await _import(path, price_date)
+    await _import(path, price_date, compute_stats_flag)
 
 
-async def _import(path: Path, price_date: datetime) -> None:
+async def _import(path: Path, price_date: datetime, compute_stats_flag: bool = True) -> None:
     chain_dirs = [d.resolve() for d in path.iterdir() if d.is_dir()]
     if not chain_dirs:
         logger.warning(f"No chain directories found in {path}")
@@ -344,15 +345,13 @@ async def _import(path: Path, price_date: datetime) -> None:
     for chain_dir in chain_dirs:
         await process_chain(price_date, chain_dir, barcodes)
 
-    logger.debug(f"Computing average chain prices for {price_date:%Y-%m-%d}")
-    await db.compute_chain_prices(price_date)
-
-    logger.debug(f"Computing chain stats for {price_date:%Y-%m-%d}")
-    await db.compute_chain_stats(price_date)
-
-    t1 = time()
-    dt = int(t1 - t0)
+    dt = int(time() - t0)
     logger.info(f"Imported {len(chain_dirs)} chains in {dt} seconds")
+
+    if compute_stats_flag:
+        await compute_stats(price_date)
+    else:
+        logger.debug(f"Skipping statistics computation for {price_date:%Y-%m-%d}")
 
 
 async def main():
@@ -382,6 +381,12 @@ async def main():
         nargs="+",
     )
     parser.add_argument(
+        "-s",
+        "--skip-stats",
+        action="store_true",
+        help="Skip computing chain stats",
+    )
+    parser.add_argument(
         "-d",
         "--debug",
         action="store_true",
@@ -394,6 +399,8 @@ async def main():
         format="%(asctime)s:%(name)s:%(levelname)s:%(message)s",
     )
 
+    compute_stats_flag = not args.skip_stats
+
     await db.connect()
 
     try:
@@ -401,9 +408,9 @@ async def main():
 
         for path in args.paths:
             if path.is_dir():
-                await import_directory(path)
+                await import_directory(path, compute_stats_flag)
             elif path.suffix.lower() == ".zip":
-                await import_archive(path)
+                await import_archive(path, compute_stats_flag)
             else:
                 logger.error(f"Path `{path}` is neither a directory nor a zip archive.")
     finally:

--- a/service/db/import.py
+++ b/service/db/import.py
@@ -331,7 +331,9 @@ async def import_directory(path: Path, compute_stats_flag: bool = True) -> None:
     await _import(path, price_date, compute_stats_flag)
 
 
-async def _import(path: Path, price_date: datetime, compute_stats_flag: bool = True) -> None:
+async def _import(
+    path: Path, price_date: datetime, compute_stats_flag: bool = True
+) -> None:
     chain_dirs = [d.resolve() for d in path.iterdir() if d.is_dir()]
     if not chain_dirs:
         logger.warning(f"No chain directories found in {path}")

--- a/service/db/stats.py
+++ b/service/db/stats.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Statistics computation service for retail chain price data.
+
+This module provides functionality to compute statistics for retail chain price data
+stored in the database. It can be used independently or as part of the import process.
+"""
+
+import argparse
+import asyncio
+import logging
+from datetime import datetime
+from time import time
+from typing import Union
+
+from service.config import settings
+
+logger = logging.getLogger("stats")
+
+db = settings.get_db()
+
+
+async def compute_stats(price_date: Union[datetime, str]) -> None:
+    """
+    Compute statistics for the given date.
+    
+    Args:
+        price_date: Either a datetime object or a date string in YYYY-MM-DD format
+    """
+    if isinstance(price_date, str):
+        try:
+            price_date = datetime.strptime(price_date, "%Y-%m-%d")
+        except ValueError:
+            logger.error(f"Invalid date format: {price_date}. Expected YYYY-MM-DD")
+            return
+    
+    logger.info(f"Computing statistics for {price_date:%Y-%m-%d}")
+    
+    t0 = time()
+    
+    logger.debug(f"Computing average chain prices for {price_date:%Y-%m-%d}")
+    await db.compute_chain_prices(price_date)
+
+    logger.debug(f"Computing chain stats for {price_date:%Y-%m-%d}")
+    await db.compute_chain_stats(price_date)
+    
+    dt = int(time() - t0)
+    logger.info(f"Computed statistics for {price_date:%Y-%m-%d} in {dt} seconds")
+
+
+async def main():
+    """
+    Standalone CLI for computing statistics.
+    
+    This allows running statistics computation independently from the import process.
+    Useful for recomputing stats on existing data or batch processing multiple dates.
+    """
+    parser = argparse.ArgumentParser(
+        description="Compute statistics for retail chain price data",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "dates",
+        help="One or more dates (YYYY-MM-DD) to compute statistics for",
+        nargs="+",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s:%(name)s:%(levelname)s:%(message)s",
+    )
+
+    await db.connect()
+
+    try:
+        for date_str in args.dates:
+            await compute_stats(date_str)
+    finally:
+        await db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/service/db/stats.py
+++ b/service/db/stats.py
@@ -23,7 +23,7 @@ db = settings.get_db()
 async def compute_stats(price_date: Union[datetime, str]) -> None:
     """
     Compute statistics for the given date.
-    
+
     Args:
         price_date: Either a datetime object or a date string in YYYY-MM-DD format
     """
@@ -33,17 +33,17 @@ async def compute_stats(price_date: Union[datetime, str]) -> None:
         except ValueError:
             logger.error(f"Invalid date format: {price_date}. Expected YYYY-MM-DD")
             return
-    
+
     logger.info(f"Computing statistics for {price_date:%Y-%m-%d}")
-    
+
     t0 = time()
-    
+
     logger.debug(f"Computing average chain prices for {price_date:%Y-%m-%d}")
     await db.compute_chain_prices(price_date)
 
     logger.debug(f"Computing chain stats for {price_date:%Y-%m-%d}")
     await db.compute_chain_stats(price_date)
-    
+
     dt = int(time() - t0)
     logger.info(f"Computed statistics for {price_date:%Y-%m-%d} in {dt} seconds")
 
@@ -51,7 +51,7 @@ async def compute_stats(price_date: Union[datetime, str]) -> None:
 async def main():
     """
     Standalone CLI for computing statistics.
-    
+
     This allows running statistics computation independently from the import process.
     Useful for recomputing stats on existing data or batch processing multiple dates.
     """
@@ -87,4 +87,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(main())


### PR DESCRIPTION
### Summary
This PR refactors the import functionality by extracting statistics computation into a dedicated service and adding an option to skip statistics computation or execute only statistics computation

#### Changes Made
- New Statistics Service (stats.py)
- Dedicated module for statistics computation with standalone CLI
- Flexible input: Accepts both datetime objects and date strings
- Independent operation: Can compute stats without running imports
- Batch processing: Support for multiple dates in a single command
- `--skip-stats `option: Skip statistics computation for faster imports
- Conditional stats: Statistics computed only when needed
- Backward compatible: Default behavior unchanged (stats still computed)


#### Benefits
- Separation of Concerns
- Import logic focuses on data processing
- Statistics logic isolated in dedicated service
- Clear boundaries between different operations
- Fast imports when statistics aren't immediately needed
- Independent stats computation for existing data
- Flexible scheduling of import vs. stats operations
- Recompute statistics without re-importing data
- Batch process stats for multiple dates
- Debug statistics independently of imports
- Backward compatible with significant performance and operational benefits