### PR TITLE
Add PostgreSQL Geospatial Extensions Support

### DIFF
--- a/service/db/psql.sql
+++ b/service/db/psql.sql
@@ -1,3 +1,7 @@
+-- Enable required PostgreSQL extensions for geospatial queries
+CREATE EXTENSION IF NOT EXISTS cube;
+CREATE EXTENSION IF NOT EXISTS earthdistance;
+
 -- Users table to store API users
 CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
This PR enables PostgreSQL geospatial query capabilities by adding the required `cube` and `earthdistance` extensions to the database schema initialization.

The database schema already includes geospatial functionality for store locations:
- Store table has `lat` and `lon` columns for coordinates
- Generated `earth_point` column using `ll_to_earth()` function for efficient spatial indexing
- GIST index on `earth_point` for fast geospatial queries
- API endpoints for filtering stores by location (`/stores/` with lat/lon parameters)

However, the required PostgreSQL extensions (`cube` and `earthdistance`) needed for these geospatial functions were not being created during database initialization, which would cause the schema setup to fail on fresh database installations.

The API endpoint `/stores/` with `lat`, `lon`, and `d` (distance) parameters can now function as intended for location-based store searches within a specified radius.

**Impact**
- Fixes database initialization on clean PostgreSQL instances
- Enables geospatial store filtering functionality in the API
- Uses `IF NOT EXISTS` clause for safe re-execution
- No breaking changes to existing functionality
