### PR TITLE
Validate CSV columns + fix problems found by validation

### DIFF
--- a/crawler/store/base.py
+++ b/crawler/store/base.py
@@ -249,7 +249,7 @@ class BaseCrawler:
             else:
                 data["price"] = data["special_price"]
 
-        if data["anchor_price"] is not None and not data.get("anchor_price_date"):
+        if data.get("anchor_price") is not None and not data.get("anchor_price_date"):
             data["anchor_price_date"] = datetime.date(2025, 5, 2).isoformat()
 
         if data["unit_price"] is None:

--- a/crawler/store/base.py
+++ b/crawler/store/base.py
@@ -325,7 +325,21 @@ class BaseCrawler:
         logger.debug("Parsing CSV content")
 
         products = []
-        for row in self.read_csv(content, delimiter=delimiter):
+        reader = self.read_csv(content, delimiter=delimiter)
+        assert reader.fieldnames is not None
+
+        # Make sure all defined columns exist in the CSV
+        csv_columns = list(reader.fieldnames)
+        price_columns = [column for column, _ in self.PRICE_MAP.values()]
+        field_columns = [column for column, _ in self.FIELD_MAP.values()]
+        for column in price_columns + field_columns:
+            if column not in csv_columns:
+                available = ", ".join(f'"{c}"' for c in csv_columns)
+                raise ValueError(
+                    f'Column "{column}" not found in CSV file. CSV columns: {available}'
+                )
+
+        for row in reader:
             try:
                 product = self.parse_csv_row(row)
             except Exception as e:

--- a/crawler/store/base.py
+++ b/crawler/store/base.py
@@ -342,8 +342,8 @@ class BaseCrawler:
         for row in reader:
             try:
                 product = self.parse_csv_row(row)
-            except Exception as e:
-                logger.warning(f"Failed to parse row: {row}: {e}")
+            except Exception:
+                logger.exception(f"Failed to parse row: {row}")
                 continue
             products.append(product)
 

--- a/crawler/store/kaufland.py
+++ b/crawler/store/kaufland.py
@@ -37,8 +37,7 @@ class KauflandCrawler(BaseCrawler):
         "quantity": ("neto količina(KG)", False),
         "unit": ("jedinica mjere", False),
         "barcode": ("barkod", False),
-        "category": ("Kategorija", False),
-        "anchor_date": ("Datum sidrenja", False),
+        "category": ("WG", False),
     }
 
     CITIES = [

--- a/crawler/store/konzum.py
+++ b/crawler/store/konzum.py
@@ -25,7 +25,7 @@ class KonzumCrawler(BaseCrawler):
         "price": ("MALOPRODAJNA CIJENA", False),
         "unit_price": ("CIJENA ZA JEDINICU MJERE", True),
         "special_price": ("MPC ZA VRIJEME POSEBNOG OBLIKA PRODAJE", False),
-        "best_price_30": ("NAJNIŽA CIJENA U POSLJEDNJIH 30 DANA", False),
+        "best_price_30": ("NAJNIŽA CIJENA U POSLJEDNIH 30 DANA", False),
         "anchor_price": ("SIDRENA CIJENA NA 2.5.2025", False),
     }
 

--- a/crawler/store/ktc.py
+++ b/crawler/store/ktc.py
@@ -26,7 +26,6 @@ class KtcCrawler(BaseCrawler):
         "unit_price": ("Cijena za jedinicu mjere", True),
         "special_price": ("MPC za vrijeme posebnog oblika prodaje", False),
         "best_price_30": ("Najniža cijena u posljednjih 30 dana", False),
-        "anchor_price": ("Sidrena cijena na 2.5.2025", False),
     }
 
     # Mapping for other fields

--- a/crawler/store/lidl.py
+++ b/crawler/store/lidl.py
@@ -43,7 +43,6 @@ class LidlCrawler(BaseCrawler):
         "unit": ("JEDINICA_MJERE", False),
         "barcode": ("BARKOD", False),
         "category": ("KATEGORIJA_PROIZVODA", False),
-        "packaging": ("PAKIRANJE", False),
     }
 
     ADDRESS_PATTERN = re.compile(

--- a/crawler/store/roto.py
+++ b/crawler/store/roto.py
@@ -41,7 +41,6 @@ class RotoCrawler(BaseCrawler):
         "unit": ("Jedinica mjere", False),
         "barcode": ("Barkod", False),
         "category": ("Kategorija proizvoda", False),
-        "packaging": ("PAKIRANJE", False),
     }
 
     def get_csv_url(self, soup: BeautifulSoup, date: datetime.date) -> str:

--- a/crawler/store/spar.py
+++ b/crawler/store/spar.py
@@ -78,11 +78,11 @@ class SparCrawler(BaseCrawler):
         "gospic",
     ]
     PRICE_MAP = {
-        "price": ("MPC", False),
-        "unit_price": ("cijena za jedinicu mjere", False),
-        "special_price": ("MPC za vrijeme posebnog oblika prodaje", False),
-        "best_price_30": ("Najniža cijena u posljednjih 30 dana", False),
-        "anchor_price": ("sidrena cijena na 2.5.2025.", False),
+        "price": ("MPC (EUR)", False),
+        "unit_price": ("cijena za jedinicu mjere (EUR)", False),
+        "special_price": ("MPC za vrijeme posebnog oblika prodaje (EUR)", False),
+        "best_price_30": ("Najniža cijena u posljednjih 30 dana (EUR)", False),
+        "anchor_price": ("sidrena cijena na 2.5.2025. (EUR)", False),
     }
 
     FIELD_MAP = {
@@ -169,10 +169,6 @@ class SparCrawler(BaseCrawler):
             f"Parsed store: {store.name} ({store.store_id}), {store.store_type}, {store.city}, {store.street_address}"
         )
         return store
-
-    def parse_csv_row(self, row: dict) -> Product:
-        fixed_row = {k.replace("(EUR)", "").strip(): v for k, v in row.items()}
-        return super().parse_csv_row(fixed_row)
 
     def get_all_products(self, date: datetime.date) -> list[Store]:
         """

--- a/crawler/store/spar.py
+++ b/crawler/store/spar.py
@@ -93,7 +93,6 @@ class SparCrawler(BaseCrawler):
         "quantity": ("neto količina", False),
         "unit": ("jedinica mjere", False),
         "category": ("kategorija proizvoda", False),
-        "anchor_price_date": ("datum sidrene cijene", False),
     }
 
     # Required to detect text encoding


### PR DESCRIPTION
This PR changes the base crawler to error if any of the columns defined in `PRICE_MAP` or `FIELD_MAP` are not found in the CSV. This help us detect changes to the CSV format rather than silently ignore them.