### PR TITLE
Ispravljene greške i dodanja poboljšanja vezana uz #58

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -22,6 +22,8 @@ TIMEZONE=Europe/Zagreb
 # =================
 HOST=0.0.0.0
 PORT=8000
+EXTERNAL_PORT=8000
+ROOT_PATH=/
 BASE_URL=http://localhost:8000
 REDIRECT_URL=https://cijene.dev
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17-alpine
+    image: postgres:16-alpine
     env_file:
       - .env
     volumes:
@@ -27,12 +27,12 @@ services:
       - ./data:/app/data
       - ./enrichment:/app/enrichment
     ports:
-      - "${PORT:-8000}:8000"
+      - "${EXTERNAL_PORT:-8000}:${PORT:-8000}"
     depends_on:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:${PORT:-8000}/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/service/config.py
+++ b/service/config.py
@@ -17,6 +17,7 @@ class Settings:
     def __init__(self):
         self.version: str = os.getenv("VERSION", "0.1.0")
         self.archive_dir: str = os.getenv("ARCHIVE_DIR", "data")
+        self.root_path: str = os.getenv("ROOT_PATH", "/")
         self.base_url: str = os.getenv("BASE_URL", "https://api.cijene.dev")
         self.host: str = os.getenv("HOST", "0.0.0.0")
         self.port: int = int(os.getenv("PORT", "8000"))

--- a/service/main.py
+++ b/service/main.py
@@ -27,6 +27,7 @@ app = FastAPI(
     description="Service for product pricing data by Croatian grocery chains",
     version=settings.version,
     debug=settings.debug,
+    root_path=settings.root_path,
     lifespan=lifespan,
     openapi_components={
         "securitySchemes": {"HTTPBearer": {"type": "http", "scheme": "bearer"}}


### PR DESCRIPTION
Fixes #58 

### PostgreSQL verzija

Nadovezujući se uz issue, smanjio sam verziju PostgreSQL baze radi kompatibilnosti na najnoviju 16 verziju. Smatram da je bitno omogućiti rad, a kasnije detaljnije pogledati i riješiti korijen problem s unaccent funkcijom u 17+ verzijama.

### Ponašanje portova i Logičko odvajanje eksternog i internog porta

Nadovezujući se na grešku za ponašanje portova, unutar docker-compose.yml bi mijenjao pod ports sa
``` - "${PORT:-8000}:8000"```
na
```- "${EXTERNAL_PORT:-8000}:${PORT:-8000}"```
tako da i bez namještanja varijabli default vrijednost se može namjestiti i uredno pokrenuti docker.
Unutar .env.docker.example sam dodao ```EXTERNAL_PORT=8000```, te bi ova promjena trebala lagano korisniku omogućiti promjenu i kontrolu na eksternim i internim portovima aplikacije kao i u drugim većim open source projektima i aplikacijama.

### Healthcheck

Odmah uz portove, unutar docker-compose.yml sam doradio healthcheck sa
```test: ["CMD", "curl", "-f", "http://localhost:8000/health"]```
na
```test: ["CMD-SHELL", "curl -f http://localhost:${PORT:-8000}/health"]```
CMD-SHELL se koristi i unutar postgresql checka, tako da je tu čisto proširivanje funkcionalnosti na interni port kakav i postgresql docker ima. Tu nije bitno dodavanje root patha koji ću dodatno objasniti u sljedećoj točki pošto python omogućava health endpoint i na običnom / rootu.

### Root path

Stvar koju sam najmanje u issue objasnio, Tu je promjena vezana i uz .env.docker.example i unutar pythona.
Problem je kod reverse proxy konfiguracije da bi me možda api namještavao na drugačiji root, npr ako želimo imati na ```http://custom-domain.com/cijene-api```, aplikacija ne bi mogla dohvaćati svoj json i prikazivati na primjer docs i pristupiti drugim endpointima jer bi smatrala da i dalje živi pod "/" rootom, odnosno na primjeru ```http://custom-domain.com```.

Tu je promjena dodavanjem varijable "ROOT_PATH" u .env.docker.example s default vrijednošću od "/" (standardna vrijednost koja se sada postavi bez varijable), a dopušta korisniku da precizira root port i time prilagodi sa svojom reverse proxy konfiguracijom. Unutar python datoteka config.py i main.py su samo dodane linije za root path logiku, male su promjene koje su samo potrebne prilikom pokretanja aplikacije i ne mijenjaju druge dijelove api-ja. Dodano je: ```self.root_path: str = os.getenv("ROOT_PATH", "/")``` u config za dohvat varijable iz .env i ```root_path=settings.root_path,``` za samo namještavanje root patha u apiju.

Dodatne linije na kraju su zbog linux line-feeda na nano i kate.

Nadam se da sam dovoljno dobro objasnio promjene i da će se commit implementirati u master kako bi svima olakšalo rad s docker verzijom aplikacije. Također se nadam da nisam previše razdužio :).
