### PR TITLE
Change Lidl RE to allow for either a dot or underscore date component separator

### DIFF
--- a/crawler/store/lidl.py
+++ b/crawler/store/lidl.py
@@ -24,7 +24,7 @@ class LidlCrawler(BaseCrawler):
     INDEX_URL = f"{BASE_URL}/cijene"
     TIMEOUT = 180.0  # Longer timeout for ZIP download
     ZIP_DATE_PATTERN = re.compile(
-        r".*/Popis_cijena_po_trgovinama_na_dan_(\d{1,2})_(\d{1,2})_(\d{4})\.zip"
+        r".*/Popis_cijena_po_trgovinama_na_dan_(\d{1,2})[_.](\d{1,2})[_.](\d{4})\.zip"
     )
 
     ANCHOR_PRICE_COLUMN = "Sidrena_cijena_na_02.05.2025"


### PR DESCRIPTION
Fixes the following error
```
$ uv run -m crawler.cli.crawl -d 2026-04-04 -c lidl output
Created directory: output
Fetching price data from lidl for 2026-04-04 ...
2026-04-12 15:34:01,436:crawler.crawl:ERROR:Error crawling lidl for 2026-04-04: No price list found for 2026-04-04
Traceback (most recent call last):
  File ".../cijene-api/crawler/crawl.py", line 102, in crawl_chain
    stores = crawler.get_all_products(date)
  File ".../cijene-api/crawler/store/lidl.py", line 131, in get_all_products
    zip_url = self.get_index(date)
  File ".../cijene-api/crawler/store/lidl.py", line 114, in get_index
    raise ValueError(f"No price list found for {date}")
ValueError: No price list found for 2026-04-04
Archive created: output/2026-04-04.zip
```
which appears due to
```
https://tvrtka.lidl.hr/cijene
[...document.querySelectorAll('div.landing-page__block a')].map(a => a.href.split('an')[1]).join('\n')
"_12_03_2026.zip
_13_03_2026.zip
_14_03_2026.zip
_15_03_2026.zip
_16_03_2026.zip
_17_03_2026.zip
_18_03_2026.zip
_19_03_2026.zip
_20_03_2026.zip
_21_03_2026.zip
_22_03_2026.zip
_23_03_2026.zip
_24_03_2026.zip
_25_03_2026.zip
_26_03_2026.zip
_27_03_2026.zip
_28_03_2026.zip
_29_03_2026.zip
_30_03_2026.zip
_31_03_2026.zip
_01_04_2026.zip
_02_04_2026.zip
_03_04_2026.zip
_04.04.2026.zip
   ^  ^
_07.04.2026.zip
_08_04_2026.zip
_09_04_2026.zip
_10_04_2026.zip
_11_04_2026.zip"
```

Possibly monitor and extend to allow for all non-digit date component separators.