### PR TITLE
crawler: adapt Lidl crawler to their new manual upload process

### DIFF
--- a/crawler/store/lidl.py
+++ b/crawler/store/lidl.py
@@ -1,7 +1,14 @@
 import datetime
 import logging
 import re
-from typing import Optional
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+from typing import Generator, Optional
+from urllib.parse import unquote, urljoin
+from zipfile import BadZipFile, ZipFile
+
+import httpx
+from bs4 import BeautifulSoup
 
 from crawler.store.models import Product, Store
 
@@ -15,17 +22,32 @@ class LidlCrawler(BaseCrawler):
     Crawler for Lidl store prices.
 
     This class handles downloading and parsing price data from Lidl's website.
-    It fetches the price list index page, finds the ZIP for the specified date,
+    It fetches the price list index pages, finds the ZIP for the specified date,
     downloads and extracts it, and parses the CSV files inside.
+
+    Since 2026-07-14 the ZIPs are uploaded manually with ad-hoc names (often
+    without a year), sometimes with the CSVs nested in a subdirectory or in a
+    ZIP within the ZIP, and are sometimes linked only from a sub-page. The date
+    parsed from the ZIP name is treated as a hint and verified against the
+    dates embedded in the CSV filenames inside.
     """
 
     CHAIN = "lidl"
     BASE_URL = "https://tvrtka.lidl.hr"
-    INDEX_URL = f"{BASE_URL}/cijene"
+    INDEX_URLS = [
+        f"{BASE_URL}/cijene",
+        f"{BASE_URL}/cijene/cijene-u-trgovinama",
+    ]
     TIMEOUT = 180.0  # Longer timeout for ZIP download
-    ZIP_DATE_PATTERN = re.compile(
-        r".*/Popis_cijena_po_trgovinama_na_dan[_.]+(\d{1,2})[_.]+(\d{1,2})[_.]+(\d{4})\.zip"
+
+    # Matches a date in an ad-hoc ZIP name, e.g. "Popis_..._na_dan_13_07_2026",
+    # "Cijene_14.07.", "CJENICI_g.a. 15.07.2026", "cijene za 16.07" (year optional)
+    ZIP_NAME_DATE_PATTERN = re.compile(
+        r"(\d{1,2})[._\s-]+(\d{1,2})(?:[._\s-]+(\d{4}))?"
     )
+
+    # Matches the date embedded in CSV filenames, e.g. "..._16.07.2026_7.15h.csv"
+    CSV_DATE_PATTERN = re.compile(r"_(\d{1,2})\.(\d{1,2})\.(\d{4})_")
 
     ANCHOR_PRICE_COLUMN = "Sidrena_cijena_na_02.05.2025"
     PRICE_MAP = {
@@ -66,6 +88,7 @@ class LidlCrawler(BaseCrawler):
         Returns:
             Store object with parsed store information, or None if parsing fails
         """
+        filename = filename.rsplit("/", 1)[-1]
         logger.debug(f"Parsing store information from filename: {filename}")
 
         try:
@@ -105,34 +128,161 @@ class LidlCrawler(BaseCrawler):
 
         return super().parse_csv_row(row)
 
-    def get_index(self, date: datetime.date) -> str:
-        content = self.fetch_text(self.INDEX_URL)
-        zip_urls_by_date = self.parse_index_for_zip(content)
-        others = ", ".join(f"{d:%Y-%m-%d}" for d in zip_urls_by_date)
-        logger.debug(f"Available price lists: {others}")
-        if date not in zip_urls_by_date:
-            raise ValueError(f"No price list found for {date}")
-        return zip_urls_by_date[date]
-
-    def get_all_products(self, date: datetime.date) -> list[Store]:
+    def parse_zip_link_date(self, href: str) -> Optional[tuple[int, int, int | None]]:
         """
-        Main method to fetch and parse all products from Lidl's price lists.
+        Extract a (day, month, year-or-None) date hint from a ZIP link.
 
-        Args:
-            date: The date for which to fetch the price list
-
-        Returns:
-            Tuple with the date and the list of Store objects,
-            each containing its products.
-
-        Raises:
-            ValueError: If the price list ZIP cannot be found or processed
+        Only the URL-decoded basename is considered, so the numeric segments
+        in the download path (e.g. /content/download/162508/) can't misfire.
         """
-        zip_url = self.get_index(date)
+        name = unquote(href).rsplit("/", 1)[-1]
+        name = name.removesuffix(".zip")
+
+        for m in self.ZIP_NAME_DATE_PATTERN.finditer(name):
+            day, month, year = m.groups()
+            day, month = int(day), int(month)
+            year = int(year) if year else None
+            if not (1 <= day <= 31 and 1 <= month <= 12):
+                continue
+            if year is not None and not (2020 <= year <= 2100):
+                continue
+            return (day, month, year)
+
+        return None
+
+    def date_from_csv_filename(self, filename: str) -> Optional[datetime.date]:
+        """Extract the date embedded in a CSV filename, if present."""
+        m = self.CSV_DATE_PATTERN.search(filename)
+        if not m:
+            return None
+        day, month, year = (int(g) for g in m.groups())
+        try:
+            return datetime.date(year, month, day)
+        except ValueError:
+            return None
+
+    def get_index(self, date: datetime.date) -> list[str]:
+        """
+        Return candidate ZIP URLs for the given date, best match first.
+
+        ZIP names since 2026-07-14 are ad-hoc and often lack a year, so
+        links matching the requested date's day and month are candidates,
+        with explicit-year matches ordered before year-less ones. Actual
+        content verification happens later against CSV filenames.
+        """
+        year_matches: list[str] = []
+        yearless_matches: list[str] = []
+        available: set[str] = set()
+        seen: set[str] = set()
+
+        for index_url in self.INDEX_URLS:
+            try:
+                content = self.fetch_text(index_url)
+            except httpx.HTTPError as e:
+                logger.warning(f"Failed to fetch index page {index_url}: {e}")
+                continue
+
+            soup = BeautifulSoup(content, "html.parser")
+            for link in soup.select('a[href$=".zip"]'):
+                url = urljoin(index_url, str(link["href"]))
+                if url in seen:
+                    continue
+                seen.add(url)
+
+                hint = self.parse_zip_link_date(url)
+                if hint is None:
+                    logger.debug(f"No date found in ZIP link, skipping: {url}")
+                    continue
+
+                day, month, year = hint
+                available.add(f"{day:02d}.{month:02d}.{year or '????'}")
+                if day != date.day or month != date.month:
+                    continue
+                if year is None:
+                    yearless_matches.append(url)
+                elif year == date.year:
+                    year_matches.append(url)
+
+        candidates = year_matches + yearless_matches
+        if not candidates:
+            raise ValueError(
+                f"No price list found for {date} (available: {sorted(available)})"
+            )
+
+        logger.info(f"Found {len(candidates)} price list candidate(s) for {date}")
+        return candidates
+
+    def get_zip_contents(
+        self, url: str, suffix: str
+    ) -> Generator[tuple[str, bytes], None, None]:
+        """
+        Download a ZIP and yield (basename, content) for matching files.
+
+        Unlike the base implementation, this handles files nested in
+        subdirectories (by yielding basenames) and unwraps one level of
+        ZIP-in-ZIP packaging, both seen in Lidl uploads since 2026-07-14.
+        """
+        with NamedTemporaryFile(mode="w+b") as temp_zip:
+            self.fetch_binary(url, temp_zip)
+            temp_zip.seek(0)
+
+            with ZipFile(temp_zip, "r") as zip_fp:
+                yield from self.yield_zip_files(zip_fp, suffix)
+
+    def yield_zip_files(
+        self, zip_fp: ZipFile, suffix: str, depth: int = 0
+    ) -> Generator[tuple[str, bytes], None, None]:
+        for file_info in zip_fp.infolist():
+            if file_info.filename.endswith("/"):
+                continue
+
+            basename = file_info.filename.rsplit("/", 1)[-1]
+
+            if basename.lower().endswith(".zip") and depth == 0:
+                logger.info(f"Unpacking nested ZIP: {file_info.filename}")
+                try:
+                    with ZipFile(BytesIO(zip_fp.read(file_info))) as inner_zip:
+                        yield from self.yield_zip_files(inner_zip, suffix, depth + 1)
+                except BadZipFile as e:
+                    logger.error(f"Invalid nested ZIP {file_info.filename}: {e}")
+                continue
+
+            if not basename.endswith(suffix):
+                continue
+
+            logger.debug(f"Processing file: {file_info.filename}")
+            try:
+                yield (basename, zip_fp.read(file_info))
+            except Exception as e:
+                logger.error(
+                    f"Error processing file {file_info.filename}: {e}",
+                    exc_info=True,
+                )
+
+    def process_zip(self, zip_url: str, date: datetime.date) -> Optional[list[Store]]:
+        """
+        Download and parse one price list ZIP, verifying it's for the right date.
+
+        Returns the parsed stores, or None if the ZIP turns out to contain
+        data for a different date (dates are taken from CSV filenames) or
+        yields no parseable stores.
+        """
         stores = []
+        verified = 0
 
         for filename, content in self.get_zip_contents(zip_url, ".csv"):
-            logger.debug(f"Processing file: {filename}")
+            csv_date = self.date_from_csv_filename(filename)
+            if csv_date is not None and csv_date != date:
+                logger.warning(
+                    f"CSV {filename} is dated {csv_date}, expected {date}; "
+                    f"discarding ZIP {zip_url}"
+                )
+                return None
+            if csv_date is not None:
+                verified += 1
+            else:
+                logger.debug(f"No date found in CSV filename: {filename}")
+
             store = self.parse_store_from_filename(filename)
             if not store:
                 logger.warning(f"Skipping CSV {filename} due to store parsing failure")
@@ -154,7 +304,37 @@ class LidlCrawler(BaseCrawler):
             store.items = products
             stores.append(store)
 
+        if not stores:
+            logger.warning(f"No stores parsed from ZIP {zip_url}")
+            return None
+
+        if verified == 0:
+            logger.warning(
+                f"Could not verify date of any CSV in {zip_url}; "
+                f"assuming it's for {date}"
+            )
+
         return stores
+
+    def get_all_products(self, date: datetime.date) -> list[Store]:
+        """
+        Main method to fetch and parse all products from Lidl's price lists.
+
+        Args:
+            date: The date for which to fetch the price list
+
+        Returns:
+            List of Store objects, each containing its products.
+
+        Raises:
+            ValueError: If the price list ZIP cannot be found or processed
+        """
+        for zip_url in self.get_index(date):
+            stores = self.process_zip(zip_url, date)
+            if stores:
+                return stores
+
+        raise ValueError(f"No valid price list found for {date}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #104.

Since 2026-07-14 Lidl appears to have switched to manually uploading their price lists. The ZIP names became ad-hoc and inconsistent (`securehub-download (Cijene_14.07.).zip`, `cijene za 16.07.zip`, ...), the CSVs moved into a subdirectory inside the ZIP, some days the payload is a ZIP inside a ZIP, and some files are only linked from the `/cijene/cijene-u-trgovinama` sub-page rather than the main price list page. Each of these independently broke the crawler.

The crawler now scrapes both pages, treats dates parsed from ZIP names as hints only (day/month match, lenient separators, optional year), verifies candidates against the dates embedded in the CSV filenames (which are still machine-generated and stable), and handles the nested directory / double-ZIP packaging.

Verified against all upload variants seen from 14.07 through 17.07, plus a byte-identical regression check on the old format (13.07).

Note: files now disappear from Lidl's site after a few days, so 14.07 and 15.07 likely can't be backfilled retroactively — the back-filling support discussed in #90 remains the long-term fix for that class of problem.